### PR TITLE
Delete repeated call startEvictor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ site-content
 /.project
 /.settings/
 /bin/
+/.idea
+/*.iml

--- a/src/main/java/org/apache/commons/pool2/impl/GenericKeyedObjectPool.java
+++ b/src/main/java/org/apache/commons/pool2/impl/GenericKeyedObjectPool.java
@@ -112,8 +112,6 @@ public class GenericKeyedObjectPool<K,T> extends BaseGenericObjectPool<T>
         this.fairness = config.getFairness();
 
         setConfig(config);
-
-        startEvictor(getTimeBetweenEvictionRunsMillis());
     }
 
     /**

--- a/src/main/java/org/apache/commons/pool2/impl/GenericObjectPool.java
+++ b/src/main/java/org/apache/commons/pool2/impl/GenericObjectPool.java
@@ -113,8 +113,6 @@ public class GenericObjectPool<T> extends BaseGenericObjectPool<T>
         idleObjects = new LinkedBlockingDeque<>(config.getFairness());
 
         setConfig(config);
-
-        startEvictor(getTimeBetweenEvictionRunsMillis());
     }
 
     /**


### PR DESCRIPTION
Constructor of class `GenericKeyedObjectPool`, `public GenericKeyedObjectPool(final KeyedPooledObjectFactory<K, T> factory, final GenericKeyedObjectPoolConfig<T> config)`,The first call to the `startEvictor` in the `setConfig` method. 
Class `GenericKeyedObjectPool` is a similar problem.