### PR TITLE
Refactor PooledObject and BaseGenericObjectPool

### DIFF
--- a/src/main/java/org/apache/commons/pool2/PooledObject.java
+++ b/src/main/java/org/apache/commons/pool2/PooledObject.java
@@ -17,7 +17,6 @@
 package org.apache.commons.pool2;
 
 import java.io.PrintWriter;
-import java.util.Deque;
 
 /**
  * Defines the wrapper that is used to track the additional information, such as
@@ -118,26 +117,6 @@ public interface PooledObject<T> extends Comparable<PooledObject<T>> {
     String toString();
 
     /**
-     * Attempts to place the pooled object in the
-     * {@link PooledObjectState#EVICTION} state.
-     *
-     * @return <code>true</code> if the object was placed in the
-     *         {@link PooledObjectState#EVICTION} state otherwise
-     *         <code>false</code>
-     */
-    boolean startEvictionTest();
-
-    /**
-     * Called to inform the object that the eviction test has ended.
-     *
-     * @param idleQueue The queue of idle objects to which the object should be
-     *                  returned
-     *
-     * @return  Currently not used
-     */
-    boolean endEvictionTest(Deque<PooledObject<T>> idleQueue);
-
-    /**
      * Allocates the object.
      *
      * @return {@code true} if the original state was {@link PooledObjectState#IDLE IDLE}
@@ -198,6 +177,12 @@ public interface PooledObject<T> extends Comparable<PooledObject<T>> {
      * @return state
      */
     PooledObjectState getState();
+
+    /**
+     * Sets the state of this object.
+     * @return state
+     */
+    void setState(PooledObjectState newState);
 
     /**
      * Marks the pooled object as abandoned.

--- a/src/main/java/org/apache/commons/pool2/PooledObject.java
+++ b/src/main/java/org/apache/commons/pool2/PooledObject.java
@@ -17,6 +17,7 @@
 package org.apache.commons.pool2;
 
 import java.io.PrintWriter;
+import java.util.Deque;
 
 /**
  * Defines the wrapper that is used to track the additional information, such as
@@ -115,6 +116,28 @@ public interface PooledObject<T> extends Comparable<PooledObject<T>> {
      */
     @Override
     String toString();
+
+    /**
+     * Attempts to place the pooled object in the
+     * {@link PooledObjectState#EVICTION} state.
+     *
+     * @return <code>true</code> if the object was placed in the
+     *         {@link PooledObjectState#EVICTION} state otherwise
+     *         <code>false</code>
+     */
+    @Deprecated
+    boolean startEvictionTest();
+
+    /**
+     * Called to inform the object that the eviction test has ended.
+     *
+     * @param idleQueue The queue of idle objects to which the object should be
+     *                  returned
+     *
+     * @return  Currently not used
+     */
+    @Deprecated
+    boolean endEvictionTest(Deque<PooledObject<T>> idleQueue);
 
     /**
      * Allocates the object.

--- a/src/main/java/org/apache/commons/pool2/impl/DefaultPooledObject.java
+++ b/src/main/java/org/apache/commons/pool2/impl/DefaultPooledObject.java
@@ -21,7 +21,6 @@ import org.apache.commons.pool2.PooledObjectState;
 import org.apache.commons.pool2.TrackedUse;
 
 import java.io.PrintWriter;
-import java.util.Deque;
 
 /**
  * This wrapper is used to track the additional information, such as state, for
@@ -150,32 +149,6 @@ public class DefaultPooledObject<T> implements PooledObject<T> {
         // TODO add other attributes
     }
 
-    @Override
-    public synchronized boolean startEvictionTest() {
-        if (state == PooledObjectState.IDLE) {
-            state = PooledObjectState.EVICTION;
-            return true;
-        }
-
-        return false;
-    }
-
-    @Override
-    public synchronized boolean endEvictionTest(
-            final Deque<PooledObject<T>> idleQueue) {
-        if (state == PooledObjectState.EVICTION) {
-            state = PooledObjectState.IDLE;
-            return true;
-        } else if (state == PooledObjectState.EVICTION_RETURN_TO_HEAD) {
-            state = PooledObjectState.IDLE;
-            if (!idleQueue.offerFirst(this)) {
-                // TODO - Should never happen
-            }
-        }
-
-        return false;
-    }
-
     /**
      * Allocates the object.
      *
@@ -251,6 +224,15 @@ public class DefaultPooledObject<T> implements PooledObject<T> {
     @Override
     public synchronized PooledObjectState getState() {
         return state;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @param newState
+     */
+    @Override
+    public synchronized void setState(PooledObjectState newState) {
+        state = newState;
     }
 
     /**

--- a/src/main/java/org/apache/commons/pool2/impl/GenericKeyedObjectPool.java
+++ b/src/main/java/org/apache/commons/pool2/impl/GenericKeyedObjectPool.java
@@ -924,7 +924,7 @@ public class GenericKeyedObjectPool<K,T> extends BaseGenericObjectPool<T>
                     continue;
                 }
 
-                if (!underTest.startEvictionTest()) {
+                if (!startEvictionTest(underTest)) {
                     // Object was borrowed in another thread
                     // Don't count this as an eviction test so reduce i;
                     i--;
@@ -974,7 +974,7 @@ public class GenericKeyedObjectPool<K,T> extends BaseGenericObjectPool<T>
                             }
                         }
                     }
-                    if (!underTest.endEvictionTest(idleObjects)) {
+                    if (!endEvictionTest(underTest, idleObjects)) {
                         // TODO - May need to add code here once additional
                         // states are used
                     }

--- a/src/main/java/org/apache/commons/pool2/impl/GenericObjectPool.java
+++ b/src/main/java/org/apache/commons/pool2/impl/GenericObjectPool.java
@@ -748,7 +748,7 @@ public class GenericObjectPool<T> extends BaseGenericObjectPool<T>
                         continue;
                     }
 
-                    if (!underTest.startEvictionTest()) {
+                    if (!startEvictionTest(underTest)) {
                         // Object was borrowed in another thread
                         // Don't count this as an eviction test so reduce i;
                         i--;
@@ -798,7 +798,7 @@ public class GenericObjectPool<T> extends BaseGenericObjectPool<T>
                                 }
                             }
                         }
-                        if (!underTest.endEvictionTest(idleObjects)) {
+                        if (!endEvictionTest(underTest, idleObjects)) {
                             // TODO - May need to add code here once additional
                             // states are used
                         }


### PR DESCRIPTION
```PooledObject``` should not pay attention to ```idleObjects``` of ```GenericObjectPool```, so there should be no ```idleQueue.offerFirst (this)``` operation in ```PooledObject```.