### PR TITLE
Fix for POOL-363

### DIFF
--- a/src/main/java/org/apache/commons/pool2/impl/EvictionTimer.java
+++ b/src/main/java/org/apache/commons/pool2/impl/EvictionTimer.java
@@ -113,14 +113,14 @@ class EvictionTimer {
     }
 
     /**
-     * Thread factory that creates a thread, with the context class loader from this class.
+     * Thread factory that creates a daemon thread, with the context class loader from this class.
      */
     private static class EvictorThreadFactory implements ThreadFactory {
 
         @Override
         public Thread newThread(final Runnable runnable) {
             final Thread thread = new Thread(null, runnable, "commons-pool-evictor-thread");
-
+            thread.setDaemon(true); // POOL-363 - Required for applications using Runtime.addShutdownHook(). --joshlandin 03.27.2019 
             AccessController.doPrivileged(new PrivilegedAction<Void>() {
                 @Override
                 public Void run() {


### PR DESCRIPTION
Updated evictor thread to be a daemon, thus no longer blocking
application hooks (added via Runtime.addShutdownHook) and causing the VM
to hang on shutdown. For example, stand-alone applications using the
Spring Framework.