### PR TITLE
(typo) Fix evictor typo

### DIFF
--- a/src/main/java/org/apache/commons/pool2/impl/BaseGenericObjectPool.java
+++ b/src/main/java/org/apache/commons/pool2/impl/BaseGenericObjectPool.java
@@ -785,7 +785,7 @@ public abstract class BaseGenericObjectPool<T> extends BaseObject {
     /**
      * Stops the evictor.
      */
-    void stopEvitor() {
+    void stopEvictor() {
         startEvictor(-1L);
     }
     /**

--- a/src/main/java/org/apache/commons/pool2/impl/GenericKeyedObjectPool.java
+++ b/src/main/java/org/apache/commons/pool2/impl/GenericKeyedObjectPool.java
@@ -688,7 +688,7 @@ public class GenericKeyedObjectPool<K, T> extends BaseGenericObjectPool<T>
 
             // Stop the evictor before the pool is closed since evict() calls
             // assertOpen()
-            stopEvitor();
+            stopEvictor();
 
             closed = true;
             // This clear removes any idle objects

--- a/src/main/java/org/apache/commons/pool2/impl/GenericObjectPool.java
+++ b/src/main/java/org/apache/commons/pool2/impl/GenericObjectPool.java
@@ -685,7 +685,7 @@ public class GenericObjectPool<T> extends BaseGenericObjectPool<T>
 
             // Stop the evictor before the pool is closed since evict() calls
             // assertOpen()
-            stopEvitor();
+            stopEvictor();
 
             closed = true;
             // This clear removes any idle objects


### PR DESCRIPTION
The typo is in a package-private method, so this change should be safe and not harm/change the public API.

----

As a side note, I noted that some of the files here have incorrect line endings (CRLF instead of Unix-style LF line endings like the rest of the project). I ran a oneliner to find all affected Java files in the tree. If someone feels like fixing this (in a separate PR) or file a JIRA ticket about it, feel free to do so.

```
$ file $(find -name \*.java ) | grep CRLF
./src/main/java/org/apache/commons/pool2/impl/BaseGenericObjectPool.java:                     ASCII text, with CRLF line terminators
./src/main/java/org/apache/commons/pool2/impl/GenericObjectPool.java:                         ASCII text, with CRLF line terminators
./src/main/java/org/apache/commons/pool2/impl/EvictionTimer.java:                             ASCII text, with CRLF line terminators
```