### PR TITLE
POOL-376 invalidateObject should not throw NPE

### DIFF
--- a/src/main/java/org/apache/commons/pool2/impl/GenericObjectPool.java
+++ b/src/main/java/org/apache/commons/pool2/impl/GenericObjectPool.java
@@ -942,7 +942,9 @@ public class GenericObjectPool<T> extends BaseGenericObjectPool<T>
             // (e.g. idleObjects.takeFirst(); then we need to provide them a fresh instance.
             // Otherwise they will be stuck forever (or until timeout)
             final PooledObject<T> freshPooled = create();
-            idleObjects.put(freshPooled);
+            if (freshPooled != null) {
+                idleObjects.put(freshPooled);
+            }
         }
     }
 


### PR DESCRIPTION
`GenericObjectPool.invalidateObject(T obj)` and/or `GenericObjectPool.destroy(PooledObject<T> toDestroy)` should not throw NullPointerException when respective parameter (`obj`/`toDestroy`) is not `null`.