### PR TITLE
POOL-356 and POOL-376

### DIFF
--- a/src/main/java/org/apache/commons/pool2/impl/GenericObjectPool.java
+++ b/src/main/java/org/apache/commons/pool2/impl/GenericObjectPool.java
@@ -581,6 +581,11 @@ public class GenericObjectPool<T> extends BaseGenericObjectPool<T>
             } catch (final Exception e) {
                 swallowException(e);
             }
+            try {
+                ensureIdle(1, false);
+            } catch (final Exception e) {
+                swallowException(e);
+            }
         } else {
             if (getLifo()) {
                 idleObjects.addFirst(p);
@@ -934,15 +939,6 @@ public class GenericObjectPool<T> extends BaseGenericObjectPool<T>
         } finally {
             destroyedCount.incrementAndGet();
             createCount.decrementAndGet();
-        }
-
-        if (idleObjects.isEmpty() && idleObjects.hasTakeWaiters()) {
-            // POOL-356.
-            // In case there are already threads waiting on something in the pool
-            // (e.g. idleObjects.takeFirst(); then we need to provide them a fresh instance.
-            // Otherwise they will be stuck forever (or until timeout)
-            final PooledObject<T> freshPooled = create();
-            idleObjects.put(freshPooled);
         }
     }
 

--- a/src/test/java/org/apache/commons/pool2/impl/TestGenericObjectPool.java
+++ b/src/test/java/org/apache/commons/pool2/impl/TestGenericObjectPool.java
@@ -2126,6 +2126,27 @@ public class TestGenericObjectPool extends TestBaseObjectPool {
         }
     }
 
+    /**
+     * POOL-376
+     */
+    @Test(timeout = 60000)
+    public void testNoInvalidateNPE() throws Exception {
+        genericObjectPool.setMaxTotal(1);
+        genericObjectPool.setTestOnCreate(true);
+        genericObjectPool.setMaxWaitMillis(-1);
+        String obj = genericObjectPool.borrowObject();
+        // Make validation fail - this will cause create() to return null
+        simpleFactory.setValid(false);
+        // Create a take waiter
+        final WaitingTestThread wtt = new WaitingTestThread(genericObjectPool, 200);
+        wtt.start();
+        // Give wtt time to start
+        Thread.sleep(200);
+        genericObjectPool.invalidateObject(obj);
+        // Now allow create to succeed so waiter can be served
+        simpleFactory.setValid(true);
+    }
+
     @Test(timeout = 60000)
     public void testMaxTotal() throws Exception {
         genericObjectPool.setMaxTotal(3);


### PR DESCRIPTION
- Resolve [POOL-356](https://issues.apache.org/jira/browse/POOL-356)
- Resolve regression issue due to #11, i.e.
  - [POOL-376](https://issues.apache.org/jira/browse/POOL-376): `invalidateObject` should not return NullPointerException
  - infinite loop in `clear`

Closes #24 