### PR TITLE
Close BufferedOutputStream in test before calling toString on underlying BufferedOutputStream

### DIFF
--- a/src/test/java/org/apache/commons/pool2/impl/TestAbandonedObjectPool.java
+++ b/src/test/java/org/apache/commons/pool2/impl/TestAbandonedObjectPool.java
@@ -273,13 +273,15 @@ public class TestAbandonedObjectPool {
         abandonedConfig.setLogAbandoned(true);
         abandonedConfig.setRemoveAbandonedTimeout(1);
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final PrintWriter pw = new PrintWriter(new BufferedOutputStream(baos));
+        final BufferedOutputStream bos = new BufferedOutputStream(baos);
+        final PrintWriter pw = new PrintWriter(bos);
         abandonedConfig.setLogWriter(pw);
         pool.setAbandonedConfig(abandonedConfig);
         pool.setTimeBetweenEvictionRunsMillis(100);
         final PooledTestObject o1 = pool.borrowObject();
         Thread.sleep(2000);
         Assert.assertTrue(o1.isDestroyed());
+        bos.flush();
         Assert.assertTrue(baos.toString().indexOf("Pooled object") >= 0);
     }
 


### PR DESCRIPTION
When an `BufferedOutputStream` instance wraps an underlying `ByteArrayOutputStream` instance,
it is [recommended](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java) to flush or close the `BufferedOutputStream` before invoking the underlying instances's `toString()`.
This pull request adds a call to the `flush` method before calls to the `toString` method.