### PR TITLE
NO-JIRA (Javadoc): Add missing @throws comment in SoftReferenceObjectPool.

### DIFF
--- a/src/main/java/org/apache/commons/pool2/impl/SoftReferenceObjectPool.java
+++ b/src/main/java/org/apache/commons/pool2/impl/SoftReferenceObjectPool.java
@@ -186,6 +186,8 @@ public class SoftReferenceObjectPool<T> extends BaseObjectPool<T> {
      *
      * @param obj
      *            instance to return to the pool
+     * @throws IllegalArgumentException
+     *            if obj is not currently part of this pool
      */
     @Override
     public synchronized void returnObject(final T obj) throws Exception {


### PR DESCRIPTION
A `@throws` documentation is missing in Javadoc of SoftReferenceObjectPool.returnObject, so I added it.