### PR TITLE
Added Automatic-Module-Name to support JPMS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
         <configuration>
           <archive>
             <manifestEntries>
-              <Automatic-Module-Name>org.apache.commons.pool2</Automatic-Module-Name>
+              <Automatic-Module-Name>${commons.module.name}</Automatic-Module-Name>
             </manifestEntries>
           </archive>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,18 @@
             </overrideCompatibilityChangeParameters>
           </parameter>
         </configuration>
-      </plugin>    
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.commons.pool2</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
       </plugins>
     </build>
 


### PR DESCRIPTION
Adding Automatic-Module-Name provides a standardized way for the JPMS Module-Path.
This makes discovering commons-pool on the Module-Path standardized and keeps support for non JPMS libraries.

Jira: [POOL-385 ](https://issues.apache.org/jira/browse/POOL-385)