### PR TITLE
Replace SingleObjectFactory with mocking object and improve test design

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,12 @@
       <version>2.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.9.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <distributionManagement>


### PR DESCRIPTION
Fixes [POOL-400](https://issues.apache.org/jira/browse/POOL-400)

### Description
Replace test class [SingleObjectFactory](https://github.com/apache/commons-pool/blob/dbb4ca0bc969464f31435867a0800fc766f31068/src/test/java/org/apache/commons/pool2/impl/TestGenericObjectPoolFactoryCreateFailure.java#L38) by mocking object created by Mockito.

<hr>

##### Key changed/added classes in this PR
- Create mocking object to replace test subclass `SingleObjectFactory`, decouple test from production code.
- Extract the AtomicBoolean attribute and use the extracted attribute in test case to check method `created()` invocation status.
- Make test logic more clear by using method stub instead of method overriding.
- Introduce Mockito dependency

<hr>