### PR TITLE
[POOL-402] Check blockWhenExhausted in hasBorrowWaiters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -363,6 +363,25 @@
           </archive>
         </configuration>
       </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.7.9</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>generate-code-coverage-report</id>
+              <phase>test</phase>
+              <goals>
+                <goal>report</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -363,25 +363,6 @@
           </archive>
         </configuration>
       </plugin>
-        <plugin>
-          <groupId>org.jacoco</groupId>
-          <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.7.9</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>prepare-agent</goal>
-              </goals>
-            </execution>
-            <execution>
-              <id>generate-code-coverage-report</id>
-              <phase>test</phase>
-              <goals>
-                <goal>report</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
       </plugins>
     </build>
 

--- a/src/main/java/org/apache/commons/pool2/impl/GenericKeyedObjectPool.java
+++ b/src/main/java/org/apache/commons/pool2/impl/GenericKeyedObjectPool.java
@@ -1280,7 +1280,7 @@ public class GenericKeyedObjectPool<K, T> extends BaseGenericObjectPool<T>
      *         {@code false}
      */
     private boolean hasBorrowWaiters() {
-        return poolMap.values().stream().anyMatch(deque -> deque != null && deque.getIdleObjects().hasTakeWaiters());
+        return getBlockWhenExhausted() && poolMap.values().stream().anyMatch(deque -> deque != null && deque.getIdleObjects().hasTakeWaiters());
     }
 
     /**

--- a/src/test/java/org/apache/commons/pool2/impl/TestGenericKeyedObjectPool.java
+++ b/src/test/java/org/apache/commons/pool2/impl/TestGenericKeyedObjectPool.java
@@ -2608,6 +2608,35 @@ public class TestGenericKeyedObjectPool extends TestKeyedObjectPool {
         assertFalse(borrower.isAlive());
     }
 
+    @Test
+    public void testReturnObjectWithBlockWhenExhausted() throws Exception {
+        gkoPool.setBlockWhenExhausted(true);
+        gkoPool.setMaxTotal(1);
+
+        // Test return object with no take waiters
+        String obj = gkoPool.borrowObject("0");
+        gkoPool.returnObject("0", obj);
+
+        // Test return object with a take waiter
+        final TestThread<String> testA = new TestThread<>(gkoPool, 1, 0, 500, false, null, "0");
+        final TestThread<String> testB = new TestThread<>(gkoPool, 1, 0, 0, false, null, "1");
+        final Thread threadA = new Thread(testA);
+        final Thread threadB = new Thread(testB);
+        threadA.start();
+        threadB.start();
+        threadA.join();
+        threadB.join();
+    }
+
+    @Test
+    public void testReturnObjectWithoutBlockWhenExhausted() throws Exception {
+        gkoPool.setBlockWhenExhausted(false);
+
+        // Test return object with no take waiters
+        String obj = gkoPool.borrowObject("0");
+        gkoPool.returnObject("0", obj);
+    }
+
 }
 
 


### PR DESCRIPTION
Hi, I am a user of Apache commons pool2. I found that the performance of `returnObject(K)` would be improved a lot if I do a pre-check `getBlockWhenExhausted()` in `hasBorrowWaiters()`. The flame graphs are shared in the following link for comparison. Thank you! 
https://drive.google.com/drive/folders/11NLW4nzGMxxPwO_xjUa_nnZGciMrkpfn?usp=sharing