### PR TITLE
[POOL-393] Improve BaseGenericObjectPool's JMX Register performance

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -69,6 +69,9 @@ The <action> type attribute can be add,update,fix,remove.
     <action dev="ggregory" type="fix" due-to="Gary Gregory">
       Fail-fast on null input for DefaultPooledObjectInfo.DefaultPooledObjectInfo(PooledObject) with a NullPointerException.
     </action>       
+    <action dev="niallp" type="fix" due-to="Shichao Yuan, Phil Steitz, Niall Pemberton" issue="POOL-393">
+       Improve BaseGenericObjectPool's JMX Register performance when creating many pools.
+    </action>
     <!-- ADD -->
     <action dev="ggregory" type="add" due-to="Gary Gregory">
       Add PooledObject.getFullDuration().

--- a/src/main/java/org/apache/commons/pool2/impl/BaseGenericObjectPool.java
+++ b/src/main/java/org/apache/commons/pool2/impl/BaseGenericObjectPool.java
@@ -1219,9 +1219,14 @@ public abstract class BaseGenericObjectPool<T, E extends Exception> extends Base
                 } else {
                     objName = new ObjectName(base + jmxNamePrefix + i);
                 }
-                mbs.registerMBean(this, objName);
-                newObjectName = objName;
-                registered = true;
+                if (!mbs.isRegistered(objName)) {
+                    mbs.registerMBean(this, objName);
+                    newObjectName = objName;
+                    registered = true;
+                } else {
+                    // Increment the index and try again
+                    i++;
+                }
             } catch (final MalformedObjectNameException e) {
                 if (BaseObjectPoolConfig.DEFAULT_JMX_NAME_PREFIX.equals(
                         jmxNamePrefix) && jmxNameBase.equals(base)) {

--- a/src/test/java/org/apache/commons/pool2/impl/TestBaseGenericObjectPool.java
+++ b/src/test/java/org/apache/commons/pool2/impl/TestBaseGenericObjectPool.java
@@ -118,7 +118,7 @@ public class TestBaseGenericObjectPool {
     }
     /**
      * POOL-393
-     * Emsure JMX registration does not add too much latency to pool creation.
+     * Ensure JMX registration does not add too much latency to pool creation.
      */
     @Test
     @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)

--- a/src/test/java/org/apache/commons/pool2/impl/TestBaseGenericObjectPool.java
+++ b/src/test/java/org/apache/commons/pool2/impl/TestBaseGenericObjectPool.java
@@ -19,14 +19,23 @@ package org.apache.commons.pool2.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.lang.management.ManagementFactory;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
 import org.apache.commons.pool2.TestException;
+import org.apache.commons.pool2.Waiter;
+import org.apache.commons.pool2.WaiterFactory;
 import org.apache.commons.pool2.impl.TestGenericObjectPool.SimpleFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  */
@@ -106,5 +115,24 @@ public class TestBaseGenericObjectPool {
             Thread.sleep(1000);
             assertEquals(0, evictingPool.getNumIdle());
         }
+    }
+    /**
+     * POOL-393
+     * Emsure JMX registration does not add too much latency to pool creation.
+     */
+    @Test
+    @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
+    public void testJMXRegistrationLatency() throws Exception {
+        final int numPools = 1000;
+        final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        final ArrayList<GenericObjectPool<Waiter, IllegalStateException>> pools = new ArrayList<>();
+        long startTime = System.currentTimeMillis();
+        for (int i = 0; i < numPools; i++) {
+            pools.add(new GenericObjectPool<Waiter, IllegalStateException>(
+                new WaiterFactory<String>(0,0,0,0,0,0), new GenericObjectPoolConfig<Waiter>()));
+        }
+        System.out.println("Duration: " + (System.currentTimeMillis() - startTime));
+        final ObjectName oname = pools.get(numPools - 1).getJmxName();
+        assertEquals(1, mbs.queryNames(oname, null).size());
     }
 }


### PR DESCRIPTION
The algorithm for generating the JMX name for newly created pools can be very slow if the number of pools is large. This PR makes a 10x improvement without changing the naming sequence.

I tried a couple of approaches - first retrieving all the registered pool names using  the MBeanServer's  **_queryNames(ObjectName, QueryExp)_** method and and then using MBeanServer's **_isRegistered(ObjectName)_** method. The later involved many more JMX calls but was slightly faster and simpler code - so this PR uses that approach.

This PR seems to provide the performance improvement without changing behavior - which Phil didn't like in https://github.com/apache/commons-pool/pull/115