### PR TITLE
Support for loom

### DIFF
--- a/src/main/java/org/apache/commons/pool2/PooledObject.java
+++ b/src/main/java/org/apache/commons/pool2/PooledObject.java
@@ -33,6 +33,8 @@ import java.util.Deque;
  */
 public interface PooledObject<T> extends Comparable<PooledObject<T>> {
 
+    ReentrantLock lock = new ReentrantLock();
+
     /**
      * Tests whether the given PooledObject is null <em>or</em> contains a null.
      *

--- a/src/main/java/org/apache/commons/pool2/impl/GenericKeyedObjectPool.java
+++ b/src/main/java/org/apache/commons/pool2/impl/GenericKeyedObjectPool.java
@@ -984,7 +984,8 @@ public class GenericKeyedObjectPool<K, T, E extends Exception> extends BaseGener
             PooledObject<T> underTest = null;
             final EvictionPolicy<T> evictionPolicy = getEvictionPolicy();
 
-            synchronized (evictionLock) {
+            try {
+                evictionLock.lock();
                 final EvictionConfig evictionConfig = new EvictionConfig(
                         getMinEvictableIdleDuration(),
                         getSoftMinEvictableIdleDuration(),
@@ -1106,6 +1107,8 @@ public class GenericKeyedObjectPool<K, T, E extends Exception> extends BaseGener
                         // states are used
                     }
                 }
+            } finally {
+                evictionLock.unlock();
             }
         }
         final AbandonedConfig ac = this.abandonedConfig;


### PR DESCRIPTION
My project uses jedis component with loom, but there are cases of pinning and even deadlocks when redis times out. By replacing synchronized with ReentrantLock in the code, the above situations will be avoided. Below is the stacktrace when pinning occurs.

```
Thread[#253,ForkJoinPool-1-worker-2,5,CarrierThreads]
    java.base/java.lang.VirtualThread$VThreadContinuation.onPinned(VirtualThread.java:180)
    java.base/jdk.internal.vm.Continuation.onPinned0(Continuation.java:398)
    java.base/jdk.internal.vm.Continuation.yield0(Continuation.java:390)
    java.base/jdk.internal.vm.Continuation.yield(Continuation.java:357)
    java.base/java.lang.VirtualThread.yieldContinuation(VirtualThread.java:370)
    java.base/java.lang.VirtualThread.parkNanos(VirtualThread.java:532)
    java.base/java.lang.System$2.parkVirtualThread(System.java:2615)
    java.base/jdk.internal.misc.VirtualThreads.park(VirtualThreads.java:67)
    java.base/java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:408)
    java.base/sun.nio.ch.Poller.poll2(Poller.java:137)
    java.base/sun.nio.ch.Poller.poll(Poller.java:102)
    java.base/sun.nio.ch.Poller.poll(Poller.java:87)
    java.base/sun.nio.ch.NioSocketImpl.park(NioSocketImpl.java:175)
    java.base/sun.nio.ch.NioSocketImpl.timedRead(NioSocketImpl.java:275)
    java.base/sun.nio.ch.NioSocketImpl.implRead(NioSocketImpl.java:299)
    java.base/sun.nio.ch.NioSocketImpl.read(NioSocketImpl.java:340)
    java.base/sun.nio.ch.NioSocketImpl$1.read(NioSocketImpl.java:789)
    java.base/java.net.Socket$SocketInputStream.read(Socket.java:1025)
    java.base/java.io.InputStream.read(InputStream.java:217)
    redis.clients.util.RedisInputStream.ensureFill(RedisInputStream.java:195)
    redis.clients.util.RedisInputStream.readByte(RedisInputStream.java:40)
    redis.clients.jedis.Protocol.process(Protocol.java:141)
    redis.clients.jedis.Protocol.read(Protocol.java:205)
    redis.clients.jedis.Connection.readProtocolWithCheckingBroken(Connection.java:306)
    redis.clients.jedis.Connection.getStatusCodeReply(Connection.java:200)
    redis.clients.jedis.BinaryJedis.quit(BinaryJedis.java:163)
    credis.java.client.pool.impl.CRedisJedisFactory.destroyObject(CRedisJedisFactory.java:57)
    org.apache.commons.pool2.impl.GenericObjectPool.destroy(GenericObjectPool.java:886)
    org.apache.commons.pool2.impl.GenericObjectPool.invalidateObject(GenericObjectPool.java:634) <== monitors:1
    redis.clients.util.Pool.returnBrokenResourceObject(Pool.java:101)
    redis.clients.util.Pool.returnBrokenResource(Pool.java:80)
    redis.clients.jedis.Jedis.close(Jedis.java:3359)
    ...
```