### PR TITLE
This patch addresses a potential deadlock scenario in `GenericObjectPool`

### DIFF
--- a/src/test/java/org/apache/commons/pool3/impl/TestGenericObjectPool.java
+++ b/src/test/java/org/apache/commons/pool3/impl/TestGenericObjectPool.java
@@ -3009,6 +3009,20 @@ public class TestGenericObjectPool extends TestBaseObjectPool {
     }
 
     /**
+     * Even if block when exhausted is set, the pool should fail to borrow when there is not a single borrowed object
+     *
+     * @throws Exception May occur in some failure modes
+     */
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testWhenNoObjectDoesNotBlock() throws Exception {
+        genericObjectPool.setMaxTotal(0);
+        genericObjectPool.setBlockWhenExhausted(true);
+        assertThrows(NoSuchElementException.class, () -> genericObjectPool.borrowObject());
+        genericObjectPool.close();
+    }
+
+    /**
      * POOL-189
      *
      * @throws Exception May occur in some failure modes


### PR DESCRIPTION
We ran into a issue in production when using commons-dbcp where a single thread will deadlock itself while connecting to mysql due to validation failure on create. We root caused this to a scenario where the thread will wait forever for object in the queue but no object is created. The code flow is as follows.
 
In `GenericObjectPool`, inside the function `borrowObject`, If `borrowMaxWaitDuration` is negative and there is not a single created object (borrowed + idle), the caller would block indefinitely, especially in single-threaded scenarios, leading to a deadlock. This can happen because even though we try to create an object during borrow, create could return null if either `getMaxTotal()` returns 0 or creation fails because of various reasons ( eg: validateObject is false with `getTestOnCreate()` ). Although less likely, this can potentially deadlock all the caller threads in multi-threaded scenario too if create() fails for a sustained period of time

- Added a check to throw a `NoSuchElementException` when there is not a single created (free + borrowed) object, preventing deadlocks.
- Introduced a corresponding test case `testWhenNoObjectDoesNotBlock` in `TestGenericObjectPool` to validate the behavior.

This ensures that the pool correctly fails to borrow objects when nothing is created, even with blocking enabled.