### PR TITLE
Fix broken downloads link in index page

### DIFF
--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -43,7 +43,7 @@
 
       <section name="Releases">
          <p>
-            See the <a href="https://commons.apache.org/proper/commons-pool/download_pool.cgi">downloads</a> page for information
+            See the <a href="https://commons.apache.org/pool/download_pool.cgi">downloads</a> page for information
             on obtaining releases.
          </p>
       </section>

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -43,7 +43,7 @@
 
       <section name="Releases">
          <p>
-            See the <a href="downloads.html">downloads</a> page for information
+            See the <a href="https://commons.apache.org/proper/commons-pool/download_pool.cgi">downloads</a> page for information
             on obtaining releases.
          </p>
       </section>


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [ ] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible but is a best-practice.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body. Note that commits might be squashed by a maintainer on merge.

This PR aims to fix the broken downloads link on the index.html page.

<img width="868" alt="image" src="https://github.com/user-attachments/assets/bdb6ba3d-3d83-4c23-9b71-385877fe04b4" />

Broken link: https://commons.apache.org/proper/commons-pool/downloads.html