### PR TITLE
[POOL-418] Do not retrieve from the blocking queue when the wait time is exhausted, and modify the corresponding test cases.

### DIFF
--- a/src/main/java/org/apache/commons/pool3/impl/GenericObjectPool.java
+++ b/src/main/java/org/apache/commons/pool3/impl/GenericObjectPool.java
@@ -307,7 +307,8 @@ public class GenericObjectPool<T, E extends Exception> extends BaseGenericObject
                 if (PooledObject.isNull(p)) {
                     try {
                         remainingWaitDuration = maxWaitDuration.minus(durationSince(startInstant));
-                        p = negativeDuration ? idleObjects.takeFirst() : idleObjects.pollFirst(maxWaitDuration);
+                        p = remainingWaitDuration.isNegative() ? null
+                                : (negativeDuration ? idleObjects.takeFirst() : idleObjects.pollFirst(maxWaitDuration));
                     } catch (final InterruptedException e) {
                         // Don't surface exception type of internal locking mechanism.
                         throw cast(e);

--- a/src/test/java/org/apache/commons/pool3/impl/TestGenericObjectPool.java
+++ b/src/test/java/org/apache/commons/pool3/impl/TestGenericObjectPool.java
@@ -1098,7 +1098,7 @@ public class TestGenericObjectPool extends TestBaseObjectPool {
         try (final GenericObjectPool<String, InterruptedException> pool = new GenericObjectPool<>(createSlowObjectFactory(Duration.ofSeconds(60)))) {
             pool.setMaxTotal(1);
             pool.setMaxWait(Duration.ofMillis(1)); // small
-            pool.setBlockWhenExhausted(false);
+            pool.setBlockWhenExhausted(true); // need to merge the calculation of wait time
             // thread1 tries creating a slow object to make pool full.
             final WaitingTestThread<InterruptedException> thread1 = new WaitingTestThread<>(pool, 0);
             thread1.start();


### PR DESCRIPTION
[issues](https://issues.apache.org/jira/projects/POOL/issues/POOL-418?filter=allissues&orderby=priority+ASC%2C+updated+DESC)