### PR TITLE
[POOL-431] Improve replenishment strategy in `GenericObjectPool.invalidateObject`

### DIFF
--- a/src/main/java/org/apache/commons/pool2/impl/GenericObjectPool.java
+++ b/src/main/java/org/apache/commons/pool2/impl/GenericObjectPool.java
@@ -913,8 +913,13 @@ public class GenericObjectPool<T> extends BaseGenericObjectPool<T>
      * {@inheritDoc}
      * <p>
      * Activation of this method decrements the active count and attempts to destroy the instance, using the provided
-     * {@link DestroyMode}. To ensure liveness of the pool, {@link #addObject()} is called to replace the invalidated
-     * instance.
+     * {@link DestroyMode}. To ensure liveness of the pool, when threads are waiting to borrow, a non-blocking
+     * attempt is made to create a replacement idle instance via {@link #addIdleObject(PooledObject)} with
+     * {@link Duration#ZERO}, directly bypassing the {@link #getMaxIdle()} gate that {@link #addObject()} enforces.
+     * Replenishment is only attempted when the object is actually destroyed (i.e. not already in
+     * {@link PooledObjectState#INVALID} state). Any exception thrown by the factory during replenishment
+     * is swallowed via {@link #swallowException(Exception)} so that the invalidation itself is never aborted
+     * by a factory failure.
      * </p>
      *
      * @throws Exception if an exception occurs destroying the object
@@ -933,10 +938,14 @@ public class GenericObjectPool<T> extends BaseGenericObjectPool<T>
         synchronized (p) {
             if (p.getState() != PooledObjectState.INVALID) {
                 destroy(p, destroyMode);
+                if (!isClosed() && idleObjects.hasTakeWaiters()) {
+                    try {
+                        addIdleObject(create(Duration.ZERO));
+                    } catch (final Exception e) {
+                        swallowException(e);
+                    }
+                }
             }
-        }
-        if (!isClosed()) {
-             addObject();
         }
     }
 

--- a/src/test/java/org/apache/commons/pool2/impl/TestAbandonedObjectPool.java
+++ b/src/test/java/org/apache/commons/pool2/impl/TestAbandonedObjectPool.java
@@ -333,10 +333,7 @@ class TestAbandonedObjectPool {
         // will deem abandoned.  Make sure it is not returned to the borrower.
         returner.start();    // short delay, then return instance
         assertTrue(pool.borrowObject().hashCode() != deadMansHash);
-        // There should be n - 2 - 1 idle instance in the pool
-        // The n - 2 instances deemed abandoned should have been replaced, but
-        // one of the new ones has been checked out.
-        assertEquals(n - 2 - 1, pool.getNumIdle());
+        assertEquals(0, pool.getNumIdle());
         assertEquals(1, pool.getNumActive());
     }
 

--- a/src/test/java/org/apache/commons/pool2/impl/TestGenericObjectPool.java
+++ b/src/test/java/org/apache/commons/pool2/impl/TestGenericObjectPool.java
@@ -2095,8 +2095,7 @@ class TestGenericObjectPool extends TestBaseObjectPool {
     }
 
     /**
-     * Verify that a thread waiting to borrow is served by the idle object created during invalidateObject replenishment,
-     * without requiring the waiter to race against a new borrower.
+     * Verify that a thread waiting to borrow is served by the idle object created during invalidateObject replenishment.
      */
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
@@ -2121,20 +2120,19 @@ class TestGenericObjectPool extends TestBaseObjectPool {
     }
 
     /**
-     * Verify that a thread waiting to borrow is served by the idle object created during invalidateObject replenishment,
-     * without requiring the waiter to race against a new borrower.
+     * Verify that {@code invalidateObject} does not attempt replenishment when no thread is waiting to borrow,
+     * i.e. the replenishment path is gated on {@code hasTakeWaiters()}.
      */
     @Test
-    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     void testInvalidateDoesNotReplenishWhenNoWaiter() throws Exception {
         final ControlledFailureFactory factory = new ControlledFailureFactory();
         final List<Exception> swallowed = new ArrayList<>();
         try (GenericObjectPool<String> pool = new GenericObjectPool<>(factory)) {
             pool.setMaxTotal(1);
-            pool.setMaxWait(Duration.ofMillis(3000));
+            pool.setSwallowedExceptionListener(swallowed::add);
 
-            final String obj = pool.borrowObject(); // pool exhausted
-            // Cause the replenishment attempt to fail.
+            final String obj = pool.borrowObject(); // pool exhausted, no thread waiting
+            // Cause the replenishment attempt to fail, in case factory called.
             factory.failOnCreate(true);
 
             pool.invalidateObject(obj);

--- a/src/test/java/org/apache/commons/pool2/impl/TestGenericObjectPool.java
+++ b/src/test/java/org/apache/commons/pool2/impl/TestGenericObjectPool.java
@@ -145,6 +145,27 @@ class TestGenericObjectPool extends TestBaseObjectPool {
         }
     }
 
+    private static final class ControlledFailureFactory extends BasePooledObjectFactory<String> {
+        private boolean failOnCreate;
+
+        @Override
+        public String create() throws InterruptedException {
+            if (failOnCreate) {
+                throw new RuntimeException("Factory fails at runtime");
+            }
+            return "created";
+        }
+
+        public void failOnCreate(boolean failOnCreate) {
+            this.failOnCreate = failOnCreate;
+        }
+
+        @Override
+        public PooledObject<String> wrap(final String obj) {
+            return new DefaultPooledObject<>(obj);
+        }
+    }
+
     private static final class DummyFactory extends BasePooledObjectFactory<Object> {
         @Override
         public Object create() {
@@ -2043,6 +2064,82 @@ class TestGenericObjectPool extends TestBaseObjectPool {
             if (thread2.thrown != null) {
                 fail(thread2.thrown.toString());
             }
+        }
+    }
+
+    /**
+     * Verify that invalidateObject does not propagate factory exceptions that occur during the waiter-replenishment
+     * attempt. The exception must be swallowed; invalidation itself must complete normally.
+     */
+    @Test
+    void testInvalidateSwallowsReplenishmentFactoryException() throws Exception {
+        final ControlledFailureFactory factory = new ControlledFailureFactory();
+        final List<Exception> swallowed = new ArrayList<>();
+        try (GenericObjectPool<String> pool = new GenericObjectPool<>(factory)) {
+            pool.setMaxTotal(1);
+            pool.setSwallowedExceptionListener(swallowed::add);
+
+            final String obj = pool.borrowObject();
+            new WaitingTestThread(pool, 0).start();
+            Thread.sleep(50);
+
+            // Cause the replenishment attempt to fail.
+            factory.failOnCreate(true);
+
+            // Must complete without throwing even though factory.makeObject() will throw.
+            pool.invalidateObject(obj);
+
+            // The swallowed list proves the exception was captured, not propagated.
+            assertFalse(swallowed.isEmpty(), "Factory exception during replenishment must be swallowed, not propagated");
+        }
+    }
+
+    /**
+     * Verify that a thread waiting to borrow is served by the idle object created during invalidateObject replenishment,
+     * without requiring the waiter to race against a new borrower.
+     */
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    void testInvalidateReplenishesWaiter() throws Exception {
+        final SimpleFactory factory = new SimpleFactory();
+        try (GenericObjectPool<String> pool = new GenericObjectPool<>(factory)) {
+            pool.setMaxTotal(1);
+            pool.setMaxWait(Duration.ofMillis(3000));
+
+            final String obj = pool.borrowObject(); // pool exhausted
+
+            // Start a waiter; it must be served by the replenishment triggered inside invalidateObject.
+            final WaitingTestThread waiter = new WaitingTestThread(pool, 0);
+            waiter.start();
+            Thread.sleep(50); // ensure the waiter is blocked
+
+            pool.invalidateObject(obj);
+
+            waiter.join(2000);
+            assertNull(waiter.thrown, "Waiter should have been served by invalidateObject replenishment, but threw: " + waiter.thrown);
+        }
+    }
+
+    /**
+     * Verify that a thread waiting to borrow is served by the idle object created during invalidateObject replenishment,
+     * without requiring the waiter to race against a new borrower.
+     */
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    void testInvalidateDoesNotReplenishWhenNoWaiter() throws Exception {
+        final ControlledFailureFactory factory = new ControlledFailureFactory();
+        final List<Exception> swallowed = new ArrayList<>();
+        try (GenericObjectPool<String> pool = new GenericObjectPool<>(factory)) {
+            pool.setMaxTotal(1);
+            pool.setMaxWait(Duration.ofMillis(3000));
+
+            final String obj = pool.borrowObject(); // pool exhausted
+            // Cause the replenishment attempt to fail.
+            factory.failOnCreate(true);
+
+            pool.invalidateObject(obj);
+
+            assertTrue(swallowed.isEmpty(), "ObjectPool not excepted to replenish when there is no waiter");
         }
     }
 


### PR DESCRIPTION
## Summary
A behavioral regression was introduced in [commons-pool 2.13.0](https://commons.apache.org/proper/commons-pool/changes.html#a2.13.0) as part of the fix for [POOL-424](https://issues.apache.org/jira/browse/POOL-424), which ensures that `invalidateObject()` replaces the destroyed instance by internally calling `addObject()`.

This PR replaces the `addObject()` replenishment call in `GenericObjectPool.invalidateObject` with a
strategy consistent with how `GenericKeyedObjectPool.invalidateObject` already handles this
via `reuseCapacity()`.

```java
// before
addObject();

// after
if (!isClosed() && idleObjects.hasTakeWaiters()) {
    try {
        addIdleObject(create(Duration.ZERO));
    } catch (final Exception e) {
        swallowException(e);
    }
}
```

## Rationale

`addObject()` brings potentially unexpected behaviour other than propogating factory fails to call site: it blocks up to `maxWait`, silently no-ops when `numIdle >= maxIdle`, creates unconditionally without checking for waiters, and propagates factory exceptions — which can cause `invalidateObject()` to throw after the
invalidation has already succeeded.

The new approach is waiter-aware (`hasTakeWaiters`), non-blocking (`Duration.ZERO`), bypasses
the `maxIdle` inventory gate, and swallows factory exceptions via `swallowException`. Pool
state is checked upfront with `!isClosed()`; lifecycle management beyond that remains the
responsibility of `close()`.

## Files changed

- `src/main/java/org/apache/commons/pool2/impl/GenericObjectPool.java`

_________________________________________________________________________





<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [ ] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
